### PR TITLE
fix: resolve ambiguity std::pair vs. std::tuple. Fixes ticket #9540

### DIFF
--- a/test/std.cpp
+++ b/test/std.cpp
@@ -21,7 +21,19 @@
 #include <utility>
 #include <string>
 
-using namespace std;
+using std::deque;
+using std::list;
+using std::vector;
+using std::set;
+using std::multiset;
+using std::map;
+using std::multimap;
+using std::stack;
+using std::queue;
+using std::priority_queue;
+using std::string;
+using std::pair;
+using std::make_pair;
 using namespace boost::assign;  
     
 template< typename K, typename V >


### PR DESCRIPTION
Seen with multiple compilers which support C++11's newly introduced std::tuple. Rather than pulling just the required entities from namespace 'std', the full namespace was pulled in instead.

Signed-off-by: Daniela Engert <dani@ngrt.de>