### PR TITLE
rvalue reference, perfect forwarding and variadic template support

### DIFF
--- a/include/boost/assign/assignment_exception.hpp
+++ b/include/boost/assign/assignment_exception.hpp
@@ -28,12 +28,12 @@ namespace boost
             assignment_exception( const char* _what ) 
             : what_( _what )
             { }
-        
-            virtual const char* what() const throw()
+
+            virtual const char* what() const BOOST_NOEXCEPT_OR_NOTHROW
             {
                 return what_;
             }
-        
+
         private:
                 const char* what_;
         };

--- a/include/boost/assign/list_inserter.hpp
+++ b/include/boost/assign/list_inserter.hpp
@@ -22,13 +22,18 @@
 #include <boost/range/begin.hpp>
 #include <boost/range/end.hpp>
 #include <boost/config.hpp>
+#include <boost/move/utility.hpp>
 #include <cstddef>
+
+#if defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) || defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
 
 #include <boost/preprocessor/repetition/enum_binary_params.hpp>
 #include <boost/preprocessor/repetition/enum_params.hpp>
 #include <boost/preprocessor/cat.hpp>
 #include <boost/preprocessor/iteration/local.hpp>
 #include <boost/preprocessor/arithmetic/inc.hpp>
+
+#endif
 
 namespace boost
 {
@@ -53,7 +58,18 @@ namespace assign_detail
         fun_repeater( std::size_t sz_, Fun r ) : sz( sz_ ), val( r )
         { }
     };
-    
+
+
+    template< class T >
+    struct is_repeater : boost::false_type {};
+
+    template< class T >
+    struct is_repeater< boost::assign_detail::repeater<T> > : boost::true_type{};
+
+    template< class Fun >
+    struct is_repeater< boost::assign_detail::fun_repeater<Fun> > : boost::true_type{};
+
+
     template< class C >
     class call_push_back
     {
@@ -62,11 +78,19 @@ namespace assign_detail
         call_push_back( C& c ) : c_( c )
         { }
         
+#if defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
         template< class T >
         void operator()( T r ) 
         {
             c_.push_back( r );
         }
+#else
+        template< class T >
+        void operator()(T&& r)
+        {
+            c_.push_back(boost::forward<T>(r));
+        }
+#endif
     };
     
     template< class C >
@@ -76,12 +100,20 @@ namespace assign_detail
     public:
         call_push_front( C& c ) : c_( c )
         { }
-        
+
+#if defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
         template< class T >
         void operator()( T r ) 
         {
             c_.push_front( r );
         }
+#else
+        template< class T >
+        void operator()(T&& r)
+        {
+            c_.push_front(boost::forward<T>(r));
+        }
+#endif
     };
     
     template< class C >
@@ -92,11 +124,19 @@ namespace assign_detail
         call_push( C& c ) : c_( c )
         { }
     
+#if defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
         template< class T >
         void operator()( T r ) 
         {
             c_.push( r );
         }
+#else
+        template< class T >
+        void operator()(T&& r)
+        {
+            c_.push(boost::forward<T>(r));
+        }
+#endif
     };
     
     template< class C >
@@ -106,12 +146,20 @@ namespace assign_detail
     public:
         call_insert( C& c ) : c_( c )
         { }
-    
+
+#if defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
         template< class T >
         void operator()( T r ) 
         {
             c_.insert( r );
         }
+#else
+        template< class T >
+        void operator()(T&& r)
+        {
+            c_.insert(boost::forward<T>(r));
+        }
+#endif
     };
 
     template< class C >
@@ -161,8 +209,9 @@ namespace assign
     template< class Function, class Argument = assign_detail::forward_n_arguments > 
     class list_inserter
     {
-        struct single_arg_type {};
-        struct n_arg_type      {};
+        struct single_arg_type   {};
+        struct n_arg_type        {};
+        struct repeater_arg_type {};
 
         typedef BOOST_DEDUCED_TYPENAME mpl::if_c< is_same<Argument,assign_detail::forward_n_arguments>::value,
                                                   n_arg_type,
@@ -186,14 +235,15 @@ namespace assign
             insert_( Argument() );
             return *this;
         }
-        
+
+#if defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
         template< class T >
         list_inserter& operator=( const T& r )
         {
             insert_( r );
             return *this;
         }
-        
+
         template< class T >
         list_inserter& operator=( assign_detail::repeater<T> r )
         {
@@ -232,6 +282,38 @@ namespace assign
         {
             return repeat_fun( r.sz, r.val ); 
         }
+#else
+        // BOOST_NO_CXX11_RVALUE_REFERENCES
+        template< class T >
+        list_inserter& operator=(T&& r)
+        {
+            return operator,(boost::forward<T>(r));
+        }
+#if defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
+        template< class T >
+        list_inserter& operator,(T&& r)
+        {
+            typedef BOOST_DEDUCED_TYPENAME mpl::if_c< assign_detail::is_repeater< T >::value,
+                repeater_arg_type,
+                arg_type >::type tag;
+
+            insert(boost::forward<T>(r), tag());
+            return *this;
+        }
+#else
+        // we add the tag as the first argument when using variadic templates
+        template< class T >
+        list_inserter& operator,(T&& r)
+        {
+            typedef BOOST_DEDUCED_TYPENAME mpl::if_c< assign_detail::is_repeater< T >::value,
+                repeater_arg_type,
+                arg_type >::type tag;
+
+            insert(tag(), boost::forward<T>(r));
+            return *this;
+        }
+#endif
+#endif
 
         template< class T >
         list_inserter& repeat( std::size_t sz, T r )
@@ -266,6 +348,7 @@ namespace assign
             return range( boost::begin(r), boost::end(r) );
         }
         
+#if defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) || defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
         template< class T >
         list_inserter& operator()( const T& t )
         {
@@ -316,7 +399,72 @@ namespace assign
         
 #include BOOST_PP_LOCAL_ITERATE()
 
-        
+#else
+        template< class... Ts >
+        list_inserter& operator()(Ts&&... ts)
+        {
+            insert(arg_type(), boost::forward<Ts>(ts)...);
+            return *this;
+        }
+
+        template< class T >
+        void insert(single_arg_type, T&& t)
+        {
+            // Special implementation for single argument overload to prevent accidental casts (type-cast using functional notation)
+            insert_(boost::forward<T>(t));
+        }
+
+        template< class T1, class T2, class... Ts >
+        void insert(single_arg_type, T1&& t1, T2&& t2, Ts&&... ts)
+        {
+            insert_(Argument(boost::forward<T1>(t1), boost::forward<T2>(t2), boost::forward<Ts>(ts)...));
+        }
+
+        template< class... Ts >
+        void insert(n_arg_type, Ts&&... ts)
+        {
+            insert_(boost::forward<Ts>(ts)...);
+        }
+
+#endif
+
+#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+
+#if defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
+
+        template< class T >
+        void insert( T&& r, arg_type)
+        {
+            insert_( boost::forward<T>(r) );
+        }
+
+        template< class T >
+        void insert(assign_detail::repeater<T> r, repeater_arg_type)
+        {
+            repeat(r.sz, r.val);
+        }
+
+        template< class Nullary_function >
+        void insert(const assign_detail::fun_repeater<Nullary_function>& r, repeater_arg_type)
+        {
+            repeat_fun(r.sz, r.val);
+        }
+#else
+        template< class T >
+        void insert(repeater_arg_type, assign_detail::repeater<T> r)
+        {
+            repeat(r.sz, r.val);
+        }
+
+        template< class Nullary_function >
+        void insert(repeater_arg_type, const assign_detail::fun_repeater<Nullary_function>& r)
+        {
+            repeat_fun(r.sz, r.val);
+        }
+#endif
+#endif
+
+
         Function fun_private() const
         {
             return insert_;
@@ -392,9 +540,13 @@ namespace assign
 } // namespace 'assign'
 } // namespace 'boost'
 
+#if defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) || defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+
 #undef BOOST_ASSIGN_PARAMS1
 #undef BOOST_ASSIGN_PARAMS2
 #undef BOOST_ASSIGN_PARAMS3
 #undef BOOST_ASSIGN_MAX_PARAMETERS
+
+#endif
 
 #endif

--- a/include/boost/assign/list_of.hpp
+++ b/include/boost/assign/list_of.hpp
@@ -28,14 +28,27 @@
 #include <boost/type_traits/detail/yes_no_type.hpp>
 #include <boost/type_traits/decay.hpp>
 #include <boost/type_traits/is_array.hpp>
+#include <boost/utility/enable_if.hpp>
+#include <boost/utility/declval.hpp>
 #include <boost/mpl/if.hpp>
+#include <boost/move/utility.hpp>
 #include <deque>
 #include <cstddef>
 #include <utility>
+#ifndef BOOST_NO_CXX11_HDR_ARRAY
+#include <array>
+#endif
+#ifndef BOOST_NO_CXX11_HDR_INITIALIZER_LIST
+#include <initializer_list>
+#endif
+
+#if defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) || defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
 
 #include <boost/preprocessor/repetition/enum_binary_params.hpp>
 #include <boost/preprocessor/repetition/enum_params.hpp>
 #include <boost/preprocessor/iteration/local.hpp>
+
+#endif
 
 #if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
 // BCB requires full type definition for is_array<> to work correctly.
@@ -49,8 +62,8 @@ namespace boost
 #if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
     template< class T, std::size_t sz >
     class array;
-#endif    
-    
+#endif
+
 namespace assign_detail
 {
     /////////////////////////////////////////////////////////////////////////
@@ -69,16 +82,20 @@ namespace assign_detail
             ::boost::decay<const T>,
             ::boost::decay<T> >::type type;
     };
-    
+
     template< class T, std::size_t sz >
     type_traits::yes_type assign_is_array( const array<T,sz>* );
+#ifndef BOOST_NO_CXX11_HDR_ARRAY
+    template< class T, std::size_t sz >
+    type_traits::yes_type assign_is_array( const std::array<T, sz>* );
+#endif
     type_traits::no_type assign_is_array( ... );
     template< class T, class U >
     type_traits::yes_type assign_is_pair( const std::pair<T,U>* );
-    type_traits::no_type assign_is_pair( ... ); 
+    type_traits::no_type assign_is_pair( ... );
 
 
-    
+
     struct array_type_tag
     {
     #if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
@@ -108,16 +125,22 @@ namespace assign_detail
     #endif
     };
 
+#ifndef BOOST_NO_CXX11_HDR_INITIALIZER_LIST
+    template< class C >
+    struct is_initializer_list : boost::false_type {};
 
-    
+    template< class E >
+    struct is_initializer_list< std::initializer_list<E> > : boost::true_type {};
+#endif
+
     template< class DerivedTAssign, class Iterator >
     class converter
     {
     public: // Range operations
         typedef Iterator iterator;
         typedef Iterator const_iterator;
-        
-        iterator begin() const 
+
+        iterator begin() const
         {
             return static_cast<const DerivedTAssign*>(this)->begin();
         }
@@ -126,14 +149,14 @@ namespace assign_detail
         {
             return static_cast<const DerivedTAssign*>(this)->end();
         }
-        
+
     public:
 
         template< class Container >
         Container convert_to_container() const
         {
             static Container* c = 0;
-            BOOST_STATIC_CONSTANT( bool, is_array_flag = sizeof( assign_detail::assign_is_array( c ) ) 
+            BOOST_STATIC_CONSTANT( bool, is_array_flag = sizeof( assign_detail::assign_is_array( c ) )
                                    == sizeof( type_traits::yes_type ) );
 
             typedef BOOST_DEDUCED_TYPENAME mpl::if_c< is_array_flag,
@@ -142,9 +165,9 @@ namespace assign_detail
 
             return convert<Container>( c, tag_type() );
         }
-        
+
     private:
-        
+
         template< class Container >
         Container convert( const Container*, default_type_tag ) const
         {
@@ -152,7 +175,7 @@ namespace assign_detail
 #if BOOST_WORKAROUND(BOOST_DINKUMWARE_STDLIB, == 1)
 // old Dinkumware doesn't support iterator type as template
             Container result;
-            iterator it  = begin(), 
+            iterator it  = begin(),
                      e   = end();
             while( it != e )
             {
@@ -174,25 +197,25 @@ namespace assign_detail
             BOOST_DEDUCED_TYPENAME remove_const<Array>::type ar;
 #else
             Array ar;
-#endif            
+#endif
             const std::size_t sz = ar.size();
             if( sz < static_cast<const DerivedTAssign*>(this)->size() )
                 BOOST_THROW_EXCEPTION( assign::assignment_exception( "array initialized with too many elements" ) );
-            std::size_t n = 0; 
-            iterator i   = begin(), 
+            std::size_t n = 0;
+            iterator i   = begin(),
                      e   = end();
             for( ; i != e; ++i, ++n )
                 ar[n] = *i;
             for( ; n < sz; ++n )
                 ar[n] = value_type();
-            return ar; 
+            return ar;
         }
 
         template< class Adapter >
         Adapter convert_to_adapter( const Adapter* = 0 ) const
         {
             Adapter a;
-            iterator i   = begin(), 
+            iterator i   = begin(),
                      e   = end();
             for( ; i != e; ++i )
                 a.push( *i );
@@ -209,7 +232,7 @@ namespace assign_detail
             adapter_converter( const converter& this_ ) : gl( this_ )
             {}
 
-            adapter_converter( const adapter_converter& r ) 
+            adapter_converter( const adapter_converter& r )
             : gl( r.gl )
             { }
 
@@ -220,11 +243,11 @@ namespace assign_detail
             }
         };
 
-    public: 
+    public:
         template< class Container >
         Container to_container( Container& c ) const
         {
-            return convert( &c, default_type_tag() ); 
+            return convert( &c, default_type_tag() );
         }
 
         adapter_converter to_adapter() const
@@ -235,7 +258,7 @@ namespace assign_detail
         template< class Adapter >
         Adapter to_adapter( Adapter& a ) const
         {
-            return this->convert_to_adapter( &a ); 
+            return this->convert_to_adapter( &a );
         }
 
         template< class Array >
@@ -262,7 +285,7 @@ namespace assign_detail
     {
         return !( l == r );
     }
-    
+
     template< class T, class I, class Range >
     inline bool operator!=( const Range& l, const converter<T,I>& r )
     {
@@ -304,7 +327,7 @@ namespace assign_detail
     {
         return !( l > r );
     }
-    
+
     template< class T, class I, class Range >
     inline bool operator>=( const converter<T,I>& l, const Range& r )
     {
@@ -318,49 +341,76 @@ namespace assign_detail
     }
 
     template< class T, class I, class Elem, class Traits >
-    inline std::basic_ostream<Elem,Traits>& 
+    inline std::basic_ostream<Elem,Traits>&
     operator<<( std::basic_ostream<Elem, Traits>& Os,
                 const converter<T,I>& r )
     {
         return Os << ::boost::make_iterator_range( r.begin(), r.end() );
     }
-    
+
     /////////////////////////////////////////////////////////////////////////
     // Part 1: flexible, but inefficient interface
-    /////////////////////////////////////////////////////////////////////////    
+    /////////////////////////////////////////////////////////////////////////
 
-    template< class T > 
-    class generic_list : 
+    template< class T >
+    class generic_list :
         public converter< generic_list< BOOST_DEDUCED_TYPENAME assign_decay<T>::type >,
-                          BOOST_DEDUCED_TYPENAME std::deque<BOOST_DEDUCED_TYPENAME 
+                          BOOST_DEDUCED_TYPENAME std::deque<BOOST_DEDUCED_TYPENAME
                                                             assign_decay<T>::type>::iterator >
     {
         typedef BOOST_DEDUCED_TYPENAME assign_decay<T>::type Ty;
         typedef std::deque<Ty>  impl_type;
         mutable impl_type       values_;
-        
+
     public:
         typedef BOOST_DEDUCED_TYPENAME impl_type::iterator         iterator;
         typedef iterator                                           const_iterator;
         typedef BOOST_DEDUCED_TYPENAME impl_type::value_type       value_type;
         typedef BOOST_DEDUCED_TYPENAME impl_type::size_type        size_type;
         typedef BOOST_DEDUCED_TYPENAME impl_type::difference_type  difference_type;
-        
+
     public:
         iterator begin() const       { return values_.begin(); }
         iterator end() const         { return values_.end(); }
         bool empty() const           { return values_.empty(); }
         size_type size() const       { return values_.size(); }
-        
+
     private:
+#if defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
         void push_back( value_type r ) { values_.push_back( r ); }
-        
+#else
+        void push_back( const value_type& r ) { values_.push_back( r ); }
+        void push_back( value_type&& r ) { values_.push_back( boost::move( r ) ); }
+#endif
     public:
         generic_list& operator,( const Ty& u )
         {
-            this->push_back( u ); 
+            this->push_back( u );
             return *this;
         }
+
+#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
+
+        generic_list& operator,( Ty&& u )
+        {
+            this->push_back( boost::move(u) );
+            return *this;
+        }
+#endif
+        generic_list& operator()( const Ty& u )
+        {
+            this->push_back( u );
+            return *this;
+        }
+
+#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
+
+        generic_list& operator()(Ty&& u)
+        {
+            this->push_back( boost::move(u) );
+            return *this;
+        }
+#endif
 
         generic_list& operator()()
         {
@@ -368,17 +418,12 @@ namespace assign_detail
             return *this;
         }
 
-        generic_list& operator()( const Ty& u )
-        {
-            this->push_back( u );
-            return *this;
-        }
-        
-       
+#if defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) || defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+
 #ifndef BOOST_ASSIGN_MAX_PARAMS // use user's value
 #define BOOST_ASSIGN_MAX_PARAMS 5
-#endif        
-#define BOOST_ASSIGN_MAX_PARAMETERS (BOOST_ASSIGN_MAX_PARAMS - 1) 
+#endif
+#define BOOST_ASSIGN_MAX_PARAMETERS (BOOST_ASSIGN_MAX_PARAMS - 1)
 #define BOOST_ASSIGN_PARAMS1(n) BOOST_PP_ENUM_PARAMS(n, class U)
 #define BOOST_ASSIGN_PARAMS2(n) BOOST_PP_ENUM_BINARY_PARAMS(n, U, const& u)
 #define BOOST_ASSIGN_PARAMS3(n) BOOST_PP_ENUM_PARAMS(n, u)
@@ -394,10 +439,18 @@ namespace assign_detail
         return *this; \
     } \
     /**/
-        
+
 #include BOOST_PP_LOCAL_ITERATE()
 
-        
+#else
+        template< class U0, class U1, class... Us >
+        generic_list& operator()(U0&& u0, U1&& u1, Us&&... us)
+        {
+            this->push_back(Ty(boost::forward<U0>(u0), boost::forward<U1>(u1), boost::forward<Us>(us)...));
+            return *this;
+        }
+#endif
+
         template< class U >
         generic_list& repeat( std::size_t sz, U u )
         {
@@ -406,7 +459,7 @@ namespace assign_detail
                 this->push_back( u );
             return *this;
         }
-        
+
         template< class Nullary_function >
         generic_list& repeat_fun( std::size_t sz, Nullary_function fun )
         {
@@ -417,27 +470,56 @@ namespace assign_detail
         }
 
         template< class SinglePassIterator >
-        generic_list& range( SinglePassIterator first, 
+        generic_list& range( SinglePassIterator first,
                              SinglePassIterator last )
         {
             for( ; first != last; ++first )
                 this->push_back( *first );
             return *this;
         }
-        
+
         template< class SinglePassRange >
         generic_list& range( const SinglePassRange& r )
         {
             return range( boost::begin(r), boost::end(r) );
         }
+#if !defined(BOOST_NO_CXX11_DECLTYPE_N3276) && !defined(BOOST_NO_CXX11_FUNCTION_TEMPLATE_DEFAULT_ARGS)
+        template< class Container,
+            class = decltype(Container(
+                boost::declval<BOOST_DEDUCED_TYPENAME std::deque<BOOST_DEDUCED_TYPENAME assign_decay<T>::type>::iterator>(),
+                boost::declval<BOOST_DEDUCED_TYPENAME std::deque<BOOST_DEDUCED_TYPENAME assign_decay<T>::type>::iterator>()
+                ))
+        >
+        operator Container() const
+        {
+            return this-> BOOST_NESTED_TEMPLATE convert_to_container<Container>();
+        }
 
+        template< class Container,
+            class = typename boost::enable_if< boost::is_same< boost::type_traits::yes_type, decltype(assign_is_array((Container*)0))> >::type,
+            class = void
+        >
+        operator Container() const
+        {
+            return this-> BOOST_NESTED_TEMPLATE convert_to_container<Container>();
+        }
+#elif !defined(BOOST_NO_CXX11_HDR_INITIALIZER_LIST) && !defined(BOOST_NO_CXX11_FUNCTION_TEMPLATE_DEFAULT_ARGS)
+        template< class Container,
+            class = typename boost::disable_if< is_initializer_list<Container> >::type
+        >
+        operator Container() const
+        {
+            return this-> BOOST_NESTED_TEMPLATE convert_to_container<Container>();
+        }
+#else
         template< class Container >
         operator Container() const
         {
             return this-> BOOST_NESTED_TEMPLATE convert_to_container<Container>();
         }
+#endif
     };
-    
+
     /////////////////////////////////////////////////////////////////////////
     // Part 2: efficient, but inconvenient interface
     /////////////////////////////////////////////////////////////////////////
@@ -470,14 +552,14 @@ namespace assign_detail
         {
             return *ref_;
         }
-        
+
     private:
         T* ref_;
 
     };
 
     template< class T >
-    inline bool operator<( const assign_reference<T>& l, 
+    inline bool operator<( const assign_reference<T>& l,
                            const assign_reference<T>& r )
     {
         return l.get_ref() < r.get_ref();
@@ -491,16 +573,16 @@ namespace assign_detail
     }
 
     template< class T >
-    inline void swap( assign_reference<T>& l, 
+    inline void swap( assign_reference<T>& l,
                       assign_reference<T>& r )
     {
         l.swap( r );
     }
 
 
-    
+
     template< class T, int N >
-    struct static_generic_list : 
+    struct static_generic_list :
         public converter< static_generic_list<T,N>, assign_reference<T>* >
     {
     private:
@@ -513,7 +595,7 @@ namespace assign_detail
         typedef std::size_t                           size_type;
         typedef std::ptrdiff_t                        difference_type;
 
-    
+
         static_generic_list( T& r ) :
             current_(1)
         {
@@ -526,7 +608,7 @@ namespace assign_detail
             return *this;
         }
 
-        iterator begin() const 
+        iterator begin() const
         {
             return &refs_[0];
         }
@@ -538,7 +620,7 @@ namespace assign_detail
 
         size_type size() const
         {
-            return static_cast<size_type>( current_ ); 
+            return static_cast<size_type>( current_ );
         }
 
         bool empty() const
@@ -547,7 +629,7 @@ namespace assign_detail
         }
 
         template< class ForwardIterator >
-        static_generic_list& range( ForwardIterator first, 
+        static_generic_list& range( ForwardIterator first,
                                     ForwardIterator last )
         {
             for( ; first != last; ++first )
@@ -567,11 +649,38 @@ namespace assign_detail
             return range( boost::begin(r), boost::end(r) );
         }
 
+#if !defined(BOOST_NO_CXX11_DECLTYPE_N3276) && !defined(BOOST_NO_CXX11_FUNCTION_TEMPLATE_DEFAULT_ARGS)
+        template< class Container,
+            class = decltype(Container(boost::declval<assign_reference<T>*>(), boost::declval<assign_reference<T>*>()))
+        >
+        operator Container() const
+        {
+            return this-> BOOST_NESTED_TEMPLATE convert_to_container<Container>();
+        }
+
+        template< class Container,
+            class = typename boost::enable_if< boost::is_same< boost::type_traits::yes_type, decltype(assign_is_array((Container*)0))> >::type,
+            class = void
+        >
+        operator Container() const
+        {
+            return this-> BOOST_NESTED_TEMPLATE convert_to_container<Container>();
+        }
+#elif !defined(BOOST_NO_CXX11_HDR_INITIALIZER_LIST) && !defined(BOOST_NO_CXX11_FUNCTION_TEMPLATE_DEFAULT_ARGS)
+        template< class Container,
+            class = typename boost::disable_if< is_initializer_list<Container> >::type
+        >
+        operator Container() const
+        {
+            return this-> BOOST_NESTED_TEMPLATE convert_to_container<Container>();
+        }
+#else
         template< class Container >
         operator Container() const
         {
             return this-> BOOST_NESTED_TEMPLATE convert_to_container<Container>();
         }
+#endif
 
     private:
         void insert( T& r )
@@ -579,9 +688,9 @@ namespace assign_detail
             refs_[current_] = r;
             ++current_;
         }
-        
+
         static_generic_list();
-        
+
         mutable assign_reference<internal_value_type> refs_[N];
         int current_;
     };
@@ -591,18 +700,35 @@ namespace assign_detail
 namespace assign
 {
     template< class T >
-    inline assign_detail::generic_list<T>
+    inline assign_detail::generic_list<BOOST_DEDUCED_TYPENAME assign_detail::assign_decay<T>::type>
     list_of()
     {
-        return assign_detail::generic_list<T>()( T() );
+        assign_detail::generic_list<BOOST_DEDUCED_TYPENAME assign_detail::assign_decay<T>::type> gl;
+        gl();
+        return gl;
     }
-    
+
+#if defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) || defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+
     template< class T >
-    inline assign_detail::generic_list<T> 
+    inline assign_detail::generic_list<T>
     list_of( const T& t )
     {
         return assign_detail::generic_list<T>()( t );
     }
+
+#else
+
+    template< class T >
+    inline assign_detail::generic_list<BOOST_DEDUCED_TYPENAME assign_detail::assign_decay<T>::type>
+    list_of(T&& t)
+    {
+        assign_detail::generic_list<BOOST_DEDUCED_TYPENAME assign_detail::assign_decay<T>::type> gl;
+        gl(boost::forward<T>(t));
+        return gl;
+    }
+
+#endif
 
     template< int N, class T >
     inline assign_detail::static_generic_list< BOOST_DEDUCED_TYPENAME assign_detail::assign_decay<T>::type,N>
@@ -610,13 +736,15 @@ namespace assign
     {
         return assign_detail::static_generic_list<BOOST_DEDUCED_TYPENAME assign_detail::assign_decay<T>::type,N>( t );
     }
-    
+
     template< int N, class T >
     inline assign_detail::static_generic_list<const BOOST_DEDUCED_TYPENAME assign_detail::assign_decay<T>::type,N>
     cref_list_of( const T& t )
     {
         return assign_detail::static_generic_list<const BOOST_DEDUCED_TYPENAME assign_detail::assign_decay<T>::type,N>( t );
     }
+
+#if defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) || defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
 
 #define BOOST_PP_LOCAL_LIMITS (1, BOOST_ASSIGN_MAX_PARAMETERS)
 #define BOOST_PP_LOCAL_MACRO(n) \
@@ -627,7 +755,7 @@ namespace assign
         return assign_detail::generic_list<T>()(u, BOOST_ASSIGN_PARAMS3(n)); \
     } \
     /**/
-    
+
 #include BOOST_PP_LOCAL_ITERATE()
 
 #define BOOST_PP_LOCAL_LIMITS (1, BOOST_ASSIGN_MAX_PARAMETERS)
@@ -639,14 +767,34 @@ namespace assign
         return assign_detail::generic_list< tuple<U, BOOST_ASSIGN_PARAMS4(n)> >()( tuple<U,BOOST_ASSIGN_PARAMS4(n)>( u, BOOST_ASSIGN_PARAMS3(n) )); \
     } \
     /**/
-    
+
 #include BOOST_PP_LOCAL_ITERATE()
 
+#else
+    template< class T, class U, class... Us >
+    inline assign_detail::generic_list<BOOST_DEDUCED_TYPENAME assign_detail::assign_decay<T>::type>
+    list_of(U&& u, Us&&... us)
+    {
+        assign_detail::generic_list<BOOST_DEDUCED_TYPENAME assign_detail::assign_decay<T>::type> gl;
+        gl(boost::forward<U>(u), boost::forward<Us>(us)...);
+        return gl;
+    }
+
+
+    template< class U, class... Us >
+    inline assign_detail::generic_list< tuple<U, Us...> >
+    tuple_list_of(U u, Us... us)
+    {
+        assign_detail::generic_list< tuple<U, Us...> > gl;
+        gl(tuple<U, Us...>(u, us...));
+        return gl;
+    }
+#endif
 
     template< class Key, class T >
     inline assign_detail::generic_list< std::pair
-        < 
-            BOOST_DEDUCED_TYPENAME assign_detail::assign_decay<Key>::type, 
+        <
+            BOOST_DEDUCED_TYPENAME assign_detail::assign_decay<Key>::type,
             BOOST_DEDUCED_TYPENAME assign_detail::assign_decay<T>::type
         > >
     map_list_of( const Key& k, const T& t )
@@ -658,8 +806,8 @@ namespace assign
 
     template< class F, class S >
     inline assign_detail::generic_list< std::pair
-        < 
-            BOOST_DEDUCED_TYPENAME assign_detail::assign_decay<F>::type, 
+        <
+            BOOST_DEDUCED_TYPENAME assign_detail::assign_decay<F>::type,
             BOOST_DEDUCED_TYPENAME assign_detail::assign_decay<S>::type
         > >
     pair_list_of( const F& f, const S& s )
@@ -672,11 +820,16 @@ namespace assign
 } // namespace 'boost'
 
 
+#if defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) || defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+
 #undef BOOST_ASSIGN_PARAMS1
 #undef BOOST_ASSIGN_PARAMS2
 #undef BOOST_ASSIGN_PARAMS3
 #undef BOOST_ASSIGN_PARAMS4
 #undef BOOST_ASSIGN_PARAMS2_NO_REF
 #undef BOOST_ASSIGN_MAX_PARAMETERS
+
+#endif
+
 
 #endif

--- a/include/boost/assign/ptr_list_inserter.hpp
+++ b/include/boost/assign/ptr_list_inserter.hpp
@@ -18,6 +18,15 @@
 #include <boost/assign/list_inserter.hpp>
 #include <boost/type_traits/remove_reference.hpp>
 #include <boost/type_traits/remove_pointer.hpp>
+#include <boost/move/utility.hpp>
+
+#if defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) || defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+
+#include <boost/preprocessor/repetition/enum_binary_params.hpp>
+#include <boost/preprocessor/repetition/enum_params.hpp>
+#include <boost/preprocessor/iteration/local.hpp>
+
+#endif
 
 namespace boost
 {
@@ -44,6 +53,8 @@ namespace assign
         ptr_list_inserter( const ptr_list_inserter& r ) : insert_( r.insert_ )
         {}
 
+
+#if defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) || defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
         ptr_list_inserter& operator()()
         {
             insert_( new obj_type() );
@@ -76,6 +87,17 @@ namespace assign
     /**/
         
 #include BOOST_PP_LOCAL_ITERATE()
+
+#else
+
+        template< class... Ts >
+        ptr_list_inserter& operator()(Ts&&... ts)
+        {
+            insert_(new obj_type(boost::forward<Ts>(ts)...));
+            return *this;
+        }
+
+#endif
 
     private:
         
@@ -156,9 +178,13 @@ namespace assign
 } // namespace 'assign'
 } // namespace 'boost'
 
+#if defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) || defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+
 #undef BOOST_ASSIGN_PARAMS1
 #undef BOOST_ASSIGN_PARAMS2
 #undef BOOST_ASSIGN_PARAMS3
 #undef BOOST_ASSIGN_MAX_PARAMETERS
+
+#endif
 
 #endif

--- a/include/boost/assign/ptr_list_of.hpp
+++ b/include/boost/assign/ptr_list_of.hpp
@@ -26,10 +26,15 @@
 #include <boost/type_traits/is_array.hpp>
 #include <boost/mpl/if.hpp>
 #include <boost/ptr_container/ptr_vector.hpp>
+#include <boost/move/utility.hpp>
+
+#if defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) || defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
 
 #include <boost/preprocessor/repetition/enum_binary_params.hpp>
 #include <boost/preprocessor/repetition/enum_params.hpp>
 #include <boost/preprocessor/iteration/local.hpp>
+
+#endif
 
 namespace boost
 {
@@ -38,12 +43,12 @@ namespace assign_detail
 {
     /////////////////////////////////////////////////////////////////////////
     // Part 1: flexible and efficient interface
-    /////////////////////////////////////////////////////////////////////////    
+    /////////////////////////////////////////////////////////////////////////
 
-    template< class T > 
-    class generic_ptr_list : 
+    template< class T >
+    class generic_ptr_list :
         public converter< generic_ptr_list<T>,
-                          BOOST_DEDUCED_TYPENAME boost::ptr_vector<T>::iterator >      
+                          BOOST_DEDUCED_TYPENAME boost::ptr_vector<T>::iterator >
     {
     protected:
         typedef boost::ptr_vector<T>       impl_type;
@@ -53,7 +58,7 @@ namespace assign_detail
         typedef std::auto_ptr<impl_type>   release_type;
 #endif	
         mutable impl_type                  values_;
-        
+
     public:
         typedef BOOST_DEDUCED_TYPENAME impl_type::iterator         iterator;
         typedef iterator                                           const_iterator;
@@ -71,7 +76,7 @@ namespace assign_detail
         {
             return values_.release();
         }
-        
+
     public:
         iterator begin() const       { return values_.begin(); }
         iterator end() const         { return values_.end(); }
@@ -82,12 +87,12 @@ namespace assign_detail
 
         operator impl_type() const
         {
-            return values_;        
+            return values_;
         }
- 
+
         template< template<class,class,class> class Seq, class U,
-                  class CA, class A > 
-        operator Seq<U,CA,A>() const 
+                  class CA, class A >
+        operator Seq<U,CA,A>() const
         {
             Seq<U,CA,A> result;
             result.transfer( result.end(), values_ );
@@ -109,7 +114,7 @@ namespace assign_detail
             std::auto_ptr<PtrContainer> res( new PtrContainer() );
 #endif	
             while( !empty() )
-                res->insert( res->end(), 
+                res->insert( res->end(),
                              values_.pop_back().release() );
             return res;
         }
@@ -122,13 +127,15 @@ namespace assign_detail
 #endif	
         to_container( const PtrContainer& c ) const
         {
-            return convert( &c ); 
+            return convert( &c );
         }
-        
+
     protected:
         void push_back( T* r ) { values_.push_back( r ); }
-        
+
     public:
+#if defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) || defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+
         generic_ptr_list& operator()()
         {
             this->push_back( new T() );
@@ -141,12 +148,12 @@ namespace assign_detail
             this->push_back( new T(u) );
             return *this;
         }
-        
-       
+
+
 #ifndef BOOST_ASSIGN_MAX_PARAMS // use user's value
 #define BOOST_ASSIGN_MAX_PARAMS 5
-#endif        
-#define BOOST_ASSIGN_MAX_PARAMETERS (BOOST_ASSIGN_MAX_PARAMS - 1) 
+#endif
+#define BOOST_ASSIGN_MAX_PARAMETERS (BOOST_ASSIGN_MAX_PARAMS - 1)
 #define BOOST_ASSIGN_PARAMS1(n) BOOST_PP_ENUM_PARAMS(n, class U)
 #define BOOST_ASSIGN_PARAMS2(n) BOOST_PP_ENUM_BINARY_PARAMS(n, U, const& u)
 #define BOOST_ASSIGN_PARAMS3(n) BOOST_PP_ENUM_PARAMS(n, u)
@@ -160,8 +167,19 @@ namespace assign_detail
         return *this; \
     } \
     /**/
-        
+
 #include BOOST_PP_LOCAL_ITERATE()
+
+#else
+        template< class... Us >
+        generic_ptr_list& operator()(Us&&... us)
+        {
+            this->push_back(new T(boost::forward<Us>(us)...));
+            return *this;
+        }
+#endif
+
+
 
     }; // class 'generic_ptr_list'
 
@@ -169,18 +187,24 @@ namespace assign_detail
 
 namespace assign
 {
+#if defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) || defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+
     template< class T >
     inline assign_detail::generic_ptr_list<T>
     ptr_list_of()
     {
-        return assign_detail::generic_ptr_list<T>()();
+        assign_detail::generic_ptr_list<T> gpl;
+        gpl();
+        return gpl;
     }
-    
+
     template< class T, class U >
-    inline assign_detail::generic_ptr_list<T> 
+    inline assign_detail::generic_ptr_list<T>
     ptr_list_of( const U& t )
     {
-        return assign_detail::generic_ptr_list<T>()( t );
+        assign_detail::generic_ptr_list<T> gpl;
+        gpl( t );
+        return gpl;
     }
 
 
@@ -193,17 +217,31 @@ namespace assign
         return assign_detail::generic_ptr_list<T>()(u, BOOST_ASSIGN_PARAMS3(n)); \
     } \
     /**/
-    
+
 #include BOOST_PP_LOCAL_ITERATE()
 
+#else
+    template< class T, class... Us >
+    inline assign_detail::generic_ptr_list<T>
+    ptr_list_of(Us&&... us)
+    {
+        assign_detail::generic_ptr_list<T> gpl;
+        gpl(boost::forward<Us>(us)...);
+        return gpl;
+    }
+
+#endif
 
 } // namespace 'assign'
 } // namespace 'boost'
 
+#if defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) || defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
 
 #undef BOOST_ASSIGN_PARAMS1
 #undef BOOST_ASSIGN_PARAMS2
 #undef BOOST_ASSIGN_PARAMS3
 #undef BOOST_ASSIGN_MAX_PARAMETERS
+
+#endif
 
 #endif

--- a/include/boost/assign/ptr_map_inserter.hpp
+++ b/include/boost/assign/ptr_map_inserter.hpp
@@ -18,6 +18,15 @@
 #include <boost/assign/list_inserter.hpp>
 #include <boost/type_traits/remove_reference.hpp>
 #include <boost/type_traits/remove_pointer.hpp>
+#include <boost/move/utility.hpp>
+
+#if defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) || defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+
+#include <boost/preprocessor/repetition/enum_binary_params.hpp>
+#include <boost/preprocessor/repetition/enum_params.hpp>
+#include <boost/preprocessor/iteration/local.hpp>
+
+#endif
 
 namespace boost
 {
@@ -38,7 +47,9 @@ namespace assign
         
         ptr_map_inserter( PtrMap& m ) : m_( m )
         {}
-        
+
+#if defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) || defined(BOOST_NO_CXX11_RVALUE_REFERENCES)       
+
         template< class Key >
         ptr_map_inserter& operator()( const Key& t )
         {
@@ -68,6 +79,16 @@ namespace assign
         
 #include BOOST_PP_LOCAL_ITERATE()
 
+#else
+    template< class Key, class... Ts >
+    ptr_map_inserter& operator()(Key&& k, Ts&&... ts)
+    {
+        key_type key(boost::forward<Key>(k));
+        m_.insert(key, new obj_type(boost::forward<Ts>(ts)...));
+        return *this;
+    }
+
+#endif
     private:
 
         ptr_map_inserter& operator=( const ptr_map_inserter& );
@@ -95,9 +116,13 @@ namespace assign
 } // namespace 'assign'
 } // namespace 'boost'
 
+#if defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) || defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+
 #undef BOOST_ASSIGN_PARAMS1
 #undef BOOST_ASSIGN_PARAMS2
 #undef BOOST_ASSIGN_PARAMS3
 #undef BOOST_ASSIGN_MAX_PARAMETERS
+
+#endif
 
 #endif

--- a/include/boost/assign/std/deque.hpp
+++ b/include/boost/assign/std/deque.hpp
@@ -18,12 +18,14 @@
 
 #include <boost/assign/list_inserter.hpp>
 #include <boost/config.hpp>
+#include <boost/move/utility.hpp>
 #include <deque>
 
 namespace boost
 {
 namespace assign
 {
+#if defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
 
     template< class V, class A, class V2 >
     inline list_inserter< assign_detail::call_push_back< std::deque<V,A> >, V > 
@@ -31,7 +33,18 @@ namespace assign
     {
         return push_back( c )( v );
     }
-        
+
+#else
+
+    template< class V, class A, class V2 >
+    inline list_inserter< assign_detail::call_push_back< std::deque<V, A> >, V >
+    operator+=(std::deque<V, A>& c, V2&& v)
+    {
+        return push_back(c)(boost::forward<V2>(v));
+    }
+
+#endif
+
 }
 }
 

--- a/include/boost/assign/std/list.hpp
+++ b/include/boost/assign/std/list.hpp
@@ -18,12 +18,14 @@
 
 #include <boost/assign/list_inserter.hpp>
 #include <boost/config.hpp>
+#include <boost/move/utility.hpp>
 #include <list>
 
 namespace boost
 {
 namespace assign
 {
+#if defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
 
     template< class V, class A, class V2 >
     inline list_inserter< assign_detail::call_push_back< std::list<V,A> >, V >
@@ -31,7 +33,18 @@ namespace assign
     {
         return push_back( c )( v );
     }
-    
+
+#else
+
+    template< class V, class A, class V2 >
+    inline list_inserter< assign_detail::call_push_back< std::list<V, A> >, V >
+    operator+=(std::list<V, A>& c, V2&& v)
+    {
+        return push_back(c)(boost::forward<V2>(v));
+    }
+
+#endif
+
 }
 }
 

--- a/include/boost/assign/std/queue.hpp
+++ b/include/boost/assign/std/queue.hpp
@@ -18,12 +18,14 @@
 
 #include <boost/assign/list_inserter.hpp>
 #include <boost/config.hpp>
+#include <boost/move/utility.hpp>
 #include <queue>
 
 namespace boost
 {
 namespace assign
 {
+#if defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
 
     template< class V, class C, class V2 >
     inline list_inserter< assign_detail::call_push< std::queue<V,C> >, V >
@@ -39,6 +41,23 @@ namespace assign
         return push( c )( v );
     }
 
+#else
+
+    template< class V, class C, class V2 >
+    inline list_inserter< assign_detail::call_push< std::queue<V, C> >, V >
+    operator+=(std::queue<V, C>& c, V2&& v)
+    {
+        return push(c)(boost::forward<V2>(v));
+    }
+
+    template< class V, class C, class V2 >
+    inline list_inserter< assign_detail::call_push< std::priority_queue<V, C> >, V >
+    operator+=(std::priority_queue<V, C>& c, V2&& v)
+    {
+        return push(c)(boost::forward<V2>(v));
+    }
+
+#endif
 }
 }
 

--- a/include/boost/assign/std/set.hpp
+++ b/include/boost/assign/std/set.hpp
@@ -18,12 +18,16 @@
 
 #include <boost/assign/list_inserter.hpp>
 #include <boost/config.hpp>
+#include <boost/move/utility.hpp>
 #include <set>
 
 namespace boost
 {
 namespace assign
 {
+
+#if defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+
     template< class K, class C, class A, class K2 >
     inline list_inserter< assign_detail::call_insert< std::set<K,C,A> >, K > 
     operator+=( std::set<K,C,A>& c, K2 k )
@@ -37,7 +41,24 @@ namespace assign
     {
         return insert( c )( k );
     }
-    
+
+#else
+
+    template< class K, class C, class A, class K2 >
+    inline list_inserter< assign_detail::call_insert< std::set<K, C, A> >, K >
+    operator+=(std::set<K, C, A>& c, K2&& k)
+    {
+        return insert(c)(boost::forward<K2>(k));
+    }
+
+    template< class K, class C, class A, class K2 >
+    inline list_inserter< assign_detail::call_insert< std::multiset<K, C, A> >, K >
+    operator+=(std::multiset<K, C, A>& c, K2&& k)
+    {
+        return insert(c)(boost::forward<K2>(k));
+    }
+
+#endif
 }
 }
 

--- a/include/boost/assign/std/slist.hpp
+++ b/include/boost/assign/std/slist.hpp
@@ -19,6 +19,7 @@
 #endif
 
 #include <boost/assign/list_inserter.hpp>
+#include <boost/move/utility.hpp>
 #ifdef BOOST_SLIST_HEADER
 # include BOOST_SLIST_HEADER
 #else
@@ -29,14 +30,22 @@ namespace boost
 {
 namespace assign
 {
-
+#if defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
     template< class V, class A, class V2 >
     inline list_inserter< assign_detail::call_push_back< BOOST_STD_EXTENSION_NAMESPACE::slist<V,A> >, V >
     operator+=( BOOST_STD_EXTENSION_NAMESPACE::slist<V,A>& c, V2 v )
     {
         return push_back( c )( v );
     }
-    
+#else
+    template< class V, class A, class V2 >
+    inline list_inserter< assign_detail::call_push_back< BOOST_STD_EXTENSION_NAMESPACE::slist<V,A> >, V >
+    operator+=( BOOST_STD_EXTENSION_NAMESPACE::slist<V,A>& c, V2&& v )
+    {
+        return push_back( c )( boost::forward<V2>(v) );
+    }
+
+#endif
 }
 }
 

--- a/include/boost/assign/std/stack.hpp
+++ b/include/boost/assign/std/stack.hpp
@@ -17,12 +17,14 @@
 
 #include <boost/assign/list_inserter.hpp>
 #include <boost/config.hpp>
+#include <boost/move/utility.hpp>
 #include <stack>
 
 namespace boost
 {
 namespace assign
 {
+#if defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
 
     template< class V, class C, class V2 >
     inline list_inserter< assign_detail::call_push< std::stack<V,C> >, V >
@@ -30,7 +32,17 @@ namespace assign
     {
        return push( c )( v );
     }
-    
+
+#else
+
+    template< class V, class C, class V2 >
+    inline list_inserter< assign_detail::call_push< std::stack<V, C> >, V >
+    operator+=(std::stack<V, C>& c, V2&& v)
+    {
+        return push(c)(boost::forward<V2>(v));
+    }
+
+#endif
 }
 }
 

--- a/include/boost/assign/std/vector.hpp
+++ b/include/boost/assign/std/vector.hpp
@@ -17,12 +17,14 @@
 
 #include <boost/assign/list_inserter.hpp>
 #include <boost/config.hpp>
+#include <boost/move/utility.hpp>
 #include <vector>
 
 namespace boost
 {
 namespace assign
 {
+#if defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
 
     template< class V, class A, class V2 >
     inline list_inserter< assign_detail::call_push_back< std::vector<V,A> >, V > 
@@ -30,7 +32,17 @@ namespace assign
     {
         return push_back( c )( v );
     }
-    
+
+#else
+
+    template< class V, class A, class V2 >
+    inline list_inserter< assign_detail::call_push_back< std::vector<V, A> >, V >
+    operator+=( std::vector<V, A>& c, V2&& v )
+    {
+        return push_back( c )( std::forward<V2>(v) );
+    }
+
+#endif
 }
 }
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -18,6 +18,7 @@ rule assign-test ( name )
 test-suite assign :
     [ assign-test basic ]
     [ assign-test std ]
+    [ assign-test array ]
     [ assign-test list_of ]
     [ assign-test ptr_list_of ]
     [ assign-test static_list_of ]

--- a/test/array.cpp
+++ b/test/array.cpp
@@ -22,18 +22,40 @@
 #include <algorithm>
 #include <iterator>
 
+#ifndef BOOST_NO_CXX11_HDR_ARRAY
+#include <array>
 
+void check_std_array()
+{
+    using namespace boost::assign;
+
+    typedef std::array<float,6> Array;
+
+    Array a = list_of(1)(2)(3)(4)(5)(6);
+
+    BOOST_CHECK_EQUAL( a[0], 1 );
+    BOOST_CHECK_EQUAL( a[5], 6 );
+    // last element is implicitly 0
+    Array a2 = list_of(1)(2)(3)(4)(5);
+    BOOST_CHECK_EQUAL( a2[5], 0 );
+    // two last elements are implicitly
+    a2 = list_of(1)(2)(3)(4);
+    BOOST_CHECK_EQUAL( a2[4], 0 );
+    BOOST_CHECK_EQUAL( a2[5], 0 );
+    // too many arguments
+    BOOST_CHECK_THROW( a2 = list_of(1)(2)(3)(4)(5)(6)(7), assignment_exception );
+}
+
+#endif
 
 void check_array()
 {
-    using namespace std;
-    using namespace boost;
     using namespace boost::assign;
 
-    typedef array<float,6> Array;
+    typedef boost::array<float,6> Array;
 
 
-#if BOOST_WORKAROUND(BOOST_DINKUMWARE_STDLIB, == 1) || BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))   
+#if BOOST_WORKAROUND(BOOST_DINKUMWARE_STDLIB, == 1) || BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
     Array a = list_of(1)(2)(3)(4)(5)(6).to_array(a);
 #else
     Array a = list_of(1)(2)(3)(4)(5)(6);
@@ -46,14 +68,14 @@ void check_array()
     Array a2 = list_of(1)(2)(3)(4)(5).to_array(a2);
 #else
     Array a2 = list_of(1)(2)(3)(4)(5);
-#endif 
+#endif
     BOOST_CHECK_EQUAL( a2[5], 0 );
     // two last elements are implicitly
-#if BOOST_WORKAROUND(BOOST_DINKUMWARE_STDLIB, == 1) || BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))   
+#if BOOST_WORKAROUND(BOOST_DINKUMWARE_STDLIB, == 1) || BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
     a2 = list_of(1))(2)(3)(4).to_array(a2);
-#else    
+#else
     a2 = list_of(1)(2)(3)(4);
-#endif    
+#endif
     BOOST_CHECK_EQUAL( a2[4], 0 );
     BOOST_CHECK_EQUAL( a2[5], 0 );
     // too many arguments
@@ -64,8 +86,6 @@ void check_array()
 #else
     BOOST_CHECK_THROW( a2 = list_of(1)(2)(3)(4)(5)(6)(7), assignment_exception );
 #endif
-    
-        
 }
 
 
@@ -78,6 +98,9 @@ test_suite* init_unit_test_suite( int argc, char* argv[] )
     test_suite* test = BOOST_TEST_SUITE( "List Test Suite" );
 
     test->add( BOOST_TEST_CASE( &check_array ) );
+#ifndef BOOST_NO_CXX11_HDR_ARRAY
+    test->add( BOOST_TEST_CASE( &check_std_array ) );
+#endif
 
     return test;
 }


### PR DESCRIPTION
Adds rvalue, perfect forwarding and variadic templates.
Variadic templates replaces boost.preprocessor (only for compilers with both rvalue and variadic templates support). This removes the max argument limitation (BOOST_ASSIGN_MAX_PARAMS).

A change was required in assign_decay (related to this boost::decay issue: https://svn.boost.org/trac/boost/ticket/7760).
