### PR TITLE
Correct spelling of "suppress"

### DIFF
--- a/doc/email_example.html
+++ b/doc/email_example.html
@@ -23,7 +23,7 @@
 <span class=preprocessor>#include </span><span class=special>&lt;</span><span class=identifier>boost</span><span class=special>/</span><span class=identifier>detail</span><span class=special>/</span><span class=identifier>workaround</span><span class=special>.</span><span class=identifier>hpp</span><span class=special>&gt;
 </span>
 <span class=preprocessor>#if </span><span class=identifier>BOOST_WORKAROUND</span><span class=special>(</span><span class=identifier>__BORLANDC__</span><span class=special>, </span><span class=identifier>BOOST_TESTED_AT</span><span class=special>(</span><span class=number>0</span><span class=identifier>x564</span><span class=special>))</span>
-###<span class=identifier>pragma </span><span class=identifier>warn </span><span class=special>-</span><span class=number>8091 </span><span class=comment>// supress warning in Boost.Test</span>
+###<span class=identifier>pragma </span><span class=identifier>warn </span><span class=special>-</span><span class=number>8091 </span><span class=comment>// suppress warning in Boost.Test</span>
 ###<span class=identifier>pragma </span><span class=identifier>warn </span><span class=special>-</span><span class=number>8057 </span><span class=comment>// unused argument argc/argv in Boost.Test</span>
 <span class=preprocessor>#endif
 </span>

--- a/doc/multi_index_container.html
+++ b/doc/multi_index_container.html
@@ -23,7 +23,7 @@
 <span class=preprocessor>#include </span><span class=special>&lt;</span><span class=identifier>boost</span><span class=special>/</span><span class=identifier>detail</span><span class=special>/</span><span class=identifier>workaround</span><span class=special>.</span><span class=identifier>hpp</span><span class=special>&gt;
 </span>
 <span class=preprocessor>#if </span><span class=identifier>BOOST_WORKAROUND</span><span class=special>(</span><span class=identifier>__BORLANDC__</span><span class=special>, </span><span class=identifier>BOOST_TESTED_AT</span><span class=special>(</span><span class=number>0</span><span class=identifier>x564</span><span class=special>))</span>
-###<span class=identifier>pragma </span><span class=identifier>warn </span><span class=special>-</span><span class=number>8091 </span><span class=comment>// supress warning in Boost.Test</span>
+###<span class=identifier>pragma </span><span class=identifier>warn </span><span class=special>-</span><span class=number>8091 </span><span class=comment>// suppress warning in Boost.Test</span>
 ###<span class=identifier>pragma </span><span class=identifier>warn </span><span class=special>-</span><span class=number>8057 </span><span class=comment>// unused argument argc/argv in Boost.Test</span>
 <span class=preprocessor>#endif
 </span>

--- a/doc/my_vector_example.html
+++ b/doc/my_vector_example.html
@@ -23,7 +23,7 @@
 <span class=preprocessor>#include </span><span class=special>&lt;</span><span class=identifier>boost</span><span class=special>/</span><span class=identifier>detail</span><span class=special>/</span><span class=identifier>workaround</span><span class=special>.</span><span class=identifier>hpp</span><span class=special>&gt;
 </span>
 <span class=preprocessor>#if </span><span class=identifier>BOOST_WORKAROUND</span><span class=special>(</span><span class=identifier>__BORLANDC__</span><span class=special>, </span><span class=identifier>BOOST_TESTED_AT</span><span class=special>(</span><span class=number>0</span><span class=identifier>x564</span><span class=special>))</span>
-###<span class=identifier>pragma </span><span class=identifier>warn </span><span class=special>-</span><span class=number>8091 </span><span class=comment>// supress warning in Boost.Test</span>
+###<span class=identifier>pragma </span><span class=identifier>warn </span><span class=special>-</span><span class=number>8091 </span><span class=comment>// suppress warning in Boost.Test</span>
 ###<span class=identifier>pragma </span><span class=identifier>warn </span><span class=special>-</span><span class=number>8057 </span><span class=comment>// unused argument argc/argv in Boost.Test</span>
 <span class=preprocessor>#endif
 </span>

--- a/test/array.cpp
+++ b/test/array.cpp
@@ -11,7 +11,7 @@
 #include <boost/detail/workaround.hpp>
 
 #if BOOST_WORKAROUND( __BORLANDC__, BOOST_TESTED_AT(0x564) )
-#  pragma warn -8091 // supress warning in Boost.Test
+#  pragma warn -8091 // suppress warning in Boost.Test
 #  pragma warn -8057 // unused argument argc/argv in Boost.Test
 #endif
 

--- a/test/basic.cpp
+++ b/test/basic.cpp
@@ -11,7 +11,7 @@
 #include <boost/detail/workaround.hpp>
 
 #if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
-#  pragma warn -8091 // supress warning in Boost.Test
+#  pragma warn -8091 // suppress warning in Boost.Test
 #  pragma warn -8057 // unused argument argc/argv in Boost.Test
 #endif
 

--- a/test/email_example.cpp
+++ b/test/email_example.cpp
@@ -12,7 +12,7 @@
 #include <boost/detail/workaround.hpp>
 
 #if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
-#  pragma warn -8091 // supress warning in Boost.Test
+#  pragma warn -8091 // suppress warning in Boost.Test
 #  pragma warn -8057 // unused argument argc/argv in Boost.Test
 #endif
 

--- a/test/list_inserter.cpp
+++ b/test/list_inserter.cpp
@@ -11,7 +11,7 @@
 #include <boost/detail/workaround.hpp>
 
 #if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
-#  pragma warn -8091 // supress warning in Boost.Test
+#  pragma warn -8091 // suppress warning in Boost.Test
 #  pragma warn -8057 // unused argument argc/argv in Boost.Test
 #endif
 

--- a/test/list_of.cpp
+++ b/test/list_of.cpp
@@ -12,7 +12,7 @@
 #include <boost/detail/workaround.hpp>
 
 #if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
-#  pragma warn -8091 // supress warning in Boost.Test
+#  pragma warn -8091 // suppress warning in Boost.Test
 #  pragma warn -8057 // unused argument argc/argv in Boost.Test
 #endif
 

--- a/test/list_of_workaround.cpp
+++ b/test/list_of_workaround.cpp
@@ -12,7 +12,7 @@
 #include <boost/detail/workaround.hpp>
 
 #if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
-#  pragma warn -8091 // supress warning in Boost.Test
+#  pragma warn -8091 // suppress warning in Boost.Test
 #  pragma warn -8057 // unused argument argc/argv in Boost.Test
 #endif
 

--- a/test/multi_index_container.cpp
+++ b/test/multi_index_container.cpp
@@ -12,7 +12,7 @@
 #include <boost/detail/workaround.hpp>
 
 #if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
-#  pragma warn -8091 // supress warning in Boost.Test
+#  pragma warn -8091 // suppress warning in Boost.Test
 #  pragma warn -8057 // unused argument argc/argv in Boost.Test
 #endif
 

--- a/test/my_vector_example.cpp
+++ b/test/my_vector_example.cpp
@@ -12,7 +12,7 @@
 #include <boost/detail/workaround.hpp>
 
 #if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
-#  pragma warn -8091 // supress warning in Boost.Test
+#  pragma warn -8091 // suppress warning in Boost.Test
 #  pragma warn -8057 // unused argument argc/argv in Boost.Test
 #endif
 

--- a/test/ptr_list_inserter.cpp
+++ b/test/ptr_list_inserter.cpp
@@ -11,7 +11,7 @@
 #include <boost/detail/workaround.hpp>
 
 #if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
-#  pragma warn -8091 // supress warning in Boost.Test
+#  pragma warn -8091 // suppress warning in Boost.Test
 #  pragma warn -8057 // unused argument argc/argv in Boost.Test
 #endif
 

--- a/test/ptr_list_of.cpp
+++ b/test/ptr_list_of.cpp
@@ -12,7 +12,7 @@
 #include <boost/detail/workaround.hpp>
 
 #if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
-#  pragma warn -8091 // supress warning in Boost.Test
+#  pragma warn -8091 // suppress warning in Boost.Test
 #  pragma warn -8057 // unused argument argc/argv in Boost.Test
 #endif
 

--- a/test/ptr_map_inserter.cpp
+++ b/test/ptr_map_inserter.cpp
@@ -11,7 +11,7 @@
 #include <boost/detail/workaround.hpp>
 
 #if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
-#  pragma warn -8091 // supress warning in Boost.Test
+#  pragma warn -8091 // suppress warning in Boost.Test
 #  pragma warn -8057 // unused argument argc/argv in Boost.Test
 #endif
 

--- a/test/static_list_of.cpp
+++ b/test/static_list_of.cpp
@@ -12,7 +12,7 @@
 #include <boost/detail/workaround.hpp>
 
 #if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
-#  pragma warn -8091 // supress warning in Boost.Test
+#  pragma warn -8091 // suppress warning in Boost.Test
 #  pragma warn -8057 // unused argument argc/argv in Boost.Test
 #endif
 

--- a/test/std.cpp
+++ b/test/std.cpp
@@ -12,7 +12,7 @@
 #include <boost/detail/workaround.hpp>
 
 #if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
-#  pragma warn -8091 // supress warning in Boost.Test
+#  pragma warn -8091 // suppress warning in Boost.Test
 #  pragma warn -8057 // unused argument argc/argv in Boost.Test
 #endif
 

--- a/test/tuple_list_of.cpp
+++ b/test/tuple_list_of.cpp
@@ -12,7 +12,7 @@
 #include <boost/detail/workaround.hpp>
 
 #if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
-#  pragma warn -8091 // supress warning in Boost.Test
+#  pragma warn -8091 // suppress warning in Boost.Test
 #  pragma warn -8057 // unused argument argc/argv in Boost.Test
 #endif
 


### PR DESCRIPTION
"Suppress" is spelled with two P's, even in British English.