### PR TITLE
Changes for Embarcadero C++ clang-based compilers, targeting Boost 1.74. Change __BORLANDC__ to BOOST_BORLANDC, which is defined in Boost conf…

### DIFF
--- a/include/boost/assign/list_of.hpp
+++ b/include/boost/assign/list_of.hpp
@@ -56,7 +56,7 @@
 
 #endif
 
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
 // BCB requires full type definition for is_array<> to work correctly.
 #include <boost/array.hpp>
 #endif
@@ -65,7 +65,7 @@ namespace boost
 {
 
 // this here is necessary to avoid compiler error in <boost/array.hpp>
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
     template< class T, std::size_t sz >
     class array;
 #endif
@@ -104,28 +104,28 @@ namespace assign_detail
 
     struct array_type_tag
     {
-    #if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+    #if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
     private:
       char dummy_;  // BCB would by default use 8 bytes
     #endif
     };
     struct adapter_type_tag
     {
-    #if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+    #if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
     private:
       char dummy_;  // BCB would by default use 8 bytes
     #endif
     };
     struct pair_type_tag
     {
-    #if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+    #if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
     private:
       char dummy_;  // BCB would by default use 8 bytes
     #endif
     };
     struct default_type_tag
     {
-    #if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+    #if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
     private:
       char dummy_;  // BCB would by default use 8 bytes
     #endif

--- a/test/array.cpp
+++ b/test/array.cpp
@@ -10,7 +10,7 @@
 
 #include <boost/detail/workaround.hpp>
 
-#if BOOST_WORKAROUND( __BORLANDC__, BOOST_TESTED_AT(0x564) )
+#if BOOST_WORKAROUND( BOOST_BORLANDC, BOOST_TESTED_AT(0x564) )
 #  pragma warn -8091 // suppress warning in Boost.Test
 #  pragma warn -8057 // unused argument argc/argv in Boost.Test
 #endif
@@ -55,7 +55,7 @@ void check_array()
     typedef boost::array<float,6> Array;
 
 
-#if BOOST_WORKAROUND(BOOST_DINKUMWARE_STDLIB, == 1) || BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if BOOST_WORKAROUND(BOOST_DINKUMWARE_STDLIB, == 1) || BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
     Array a = list_of(1)(2)(3)(4)(5)(6).to_array(a);
 #else
     Array a = list_of(1)(2)(3)(4)(5)(6);
@@ -64,14 +64,14 @@ void check_array()
     BOOST_CHECK_EQUAL( a[0], 1 );
     BOOST_CHECK_EQUAL( a[5], 6 );
     // last element is implicitly 0
-#if BOOST_WORKAROUND(BOOST_DINKUMWARE_STDLIB, == 1) || BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if BOOST_WORKAROUND(BOOST_DINKUMWARE_STDLIB, == 1) || BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
     Array a2 = list_of(1)(2)(3)(4)(5).to_array(a2);
 #else
     Array a2 = list_of(1)(2)(3)(4)(5);
 #endif
     BOOST_CHECK_EQUAL( a2[5], 0 );
     // two last elements are implicitly
-#if BOOST_WORKAROUND(BOOST_DINKUMWARE_STDLIB, == 1) || BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if BOOST_WORKAROUND(BOOST_DINKUMWARE_STDLIB, == 1) || BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
     a2 = list_of(1))(2)(3)(4).to_array(a2);
 #else
     a2 = list_of(1)(2)(3)(4);
@@ -79,7 +79,7 @@ void check_array()
     BOOST_CHECK_EQUAL( a2[4], 0 );
     BOOST_CHECK_EQUAL( a2[5], 0 );
     // too many arguments
-#if BOOST_WORKAROUND(BOOST_DINKUMWARE_STDLIB, == 1) || BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if BOOST_WORKAROUND(BOOST_DINKUMWARE_STDLIB, == 1) || BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
 
     BOOST_CHECK_THROW( a2 = list_of(1)(2)(3)(4)(5)(6)(6).to_array(a2),
                        assignment_exception );

--- a/test/basic.cpp
+++ b/test/basic.cpp
@@ -10,7 +10,7 @@
 
 #include <boost/detail/workaround.hpp>
 
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
 #  pragma warn -8091 // suppress warning in Boost.Test
 #  pragma warn -8057 // unused argument argc/argv in Boost.Test
 #endif

--- a/test/email_example.cpp
+++ b/test/email_example.cpp
@@ -11,7 +11,7 @@
 
 #include <boost/detail/workaround.hpp>
 
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
 #  pragma warn -8091 // suppress warning in Boost.Test
 #  pragma warn -8057 // unused argument argc/argv in Boost.Test
 #endif

--- a/test/list_inserter.cpp
+++ b/test/list_inserter.cpp
@@ -10,7 +10,7 @@
 
 #include <boost/detail/workaround.hpp>
 
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
 #  pragma warn -8091 // suppress warning in Boost.Test
 #  pragma warn -8057 // unused argument argc/argv in Boost.Test
 #endif
@@ -114,7 +114,7 @@ void check_list_inserter()
     BOOST_CHECK_EQUAL( m["foo"], 2 );
 
 
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564)) \
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564)) \
     || BOOST_WORKAROUND(BOOST_MSVC, <=1300) \
     || BOOST_WORKAROUND(BOOST_MSVC, ==1700) \
     || !defined( BOOST_NO_CXX11_HDR_INITIALIZER_LIST )

--- a/test/list_of.cpp
+++ b/test/list_of.cpp
@@ -11,7 +11,7 @@
 
 #include <boost/detail/workaround.hpp>
 
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
 #  pragma warn -8091 // suppress warning in Boost.Test
 #  pragma warn -8057 // unused argument argc/argv in Boost.Test
 #endif
@@ -97,7 +97,7 @@ void test_sequence_list_of_int()
     C c3 = ba::list_of(1).repeat( 1, 2 )(3);
     BOOST_CHECK_EQUAL( c3.size(), 3u );
         
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
     // BCB fails to use operator=() directly, 
     // it must be worked around using e.g. auxiliary variable
     C aux = ba::list_of(1).repeat_fun( 10, &rand )(2)(3);

--- a/test/list_of_workaround.cpp
+++ b/test/list_of_workaround.cpp
@@ -11,7 +11,7 @@
 
 #include <boost/detail/workaround.hpp>
 
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
 #  pragma warn -8091 // suppress warning in Boost.Test
 #  pragma warn -8057 // unused argument argc/argv in Boost.Test
 #endif

--- a/test/multi_index_container.cpp
+++ b/test/multi_index_container.cpp
@@ -11,7 +11,7 @@
 
 #include <boost/detail/workaround.hpp>
 
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
 #  pragma warn -8091 // suppress warning in Boost.Test
 #  pragma warn -8057 // unused argument argc/argv in Boost.Test
 #endif

--- a/test/my_vector_example.cpp
+++ b/test/my_vector_example.cpp
@@ -11,7 +11,7 @@
 
 #include <boost/detail/workaround.hpp>
 
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
 #  pragma warn -8091 // suppress warning in Boost.Test
 #  pragma warn -8057 // unused argument argc/argv in Boost.Test
 #endif

--- a/test/ptr_list_inserter.cpp
+++ b/test/ptr_list_inserter.cpp
@@ -10,7 +10,7 @@
 
 #include <boost/detail/workaround.hpp>
 
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
 #  pragma warn -8091 // suppress warning in Boost.Test
 #  pragma warn -8057 // unused argument argc/argv in Boost.Test
 #endif

--- a/test/ptr_list_of.cpp
+++ b/test/ptr_list_of.cpp
@@ -11,7 +11,7 @@
 
 #include <boost/detail/workaround.hpp>
 
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
 #  pragma warn -8091 // suppress warning in Boost.Test
 #  pragma warn -8057 // unused argument argc/argv in Boost.Test
 #endif

--- a/test/ptr_map_inserter.cpp
+++ b/test/ptr_map_inserter.cpp
@@ -10,7 +10,7 @@
 
 #include <boost/detail/workaround.hpp>
 
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
 #  pragma warn -8091 // suppress warning in Boost.Test
 #  pragma warn -8057 // unused argument argc/argv in Boost.Test
 #endif

--- a/test/static_list_of.cpp
+++ b/test/static_list_of.cpp
@@ -11,7 +11,7 @@
 
 #include <boost/detail/workaround.hpp>
 
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
 #  pragma warn -8091 // suppress warning in Boost.Test
 #  pragma warn -8057 // unused argument argc/argv in Boost.Test
 #endif

--- a/test/std.cpp
+++ b/test/std.cpp
@@ -11,7 +11,7 @@
 
 #include <boost/detail/workaround.hpp>
 
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
 #  pragma warn -8091 // suppress warning in Boost.Test
 #  pragma warn -8057 // unused argument argc/argv in Boost.Test
 #endif

--- a/test/tuple_list_of.cpp
+++ b/test/tuple_list_of.cpp
@@ -11,7 +11,7 @@
 
 #include <boost/detail/workaround.hpp>
 
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
 #  pragma warn -8091 // suppress warning in Boost.Test
 #  pragma warn -8057 // unused argument argc/argv in Boost.Test
 #endif


### PR DESCRIPTION
…ig for the Embarcadero non-clang-based compilers.