### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,6 @@ target_link_libraries(boost_assign
     Boost::preprocessor
     Boost::ptr_container
     Boost::range
-    Boost::static_assert
     Boost::throw_exception
     Boost::tuple
     Boost::type_traits

--- a/build.jam
+++ b/build.jam
@@ -13,7 +13,6 @@ constant boost_dependencies :
     /boost/preprocessor//boost_preprocessor
     /boost/ptr_container//boost_ptr_container
     /boost/range//boost_range
-    /boost/static_assert//boost_static_assert
     /boost/throw_exception//boost_throw_exception
     /boost/tuple//boost_tuple
     /boost/type_traits//boost_type_traits ;


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.